### PR TITLE
Add CLAUDE.md and polish docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+`gloggles.nvim` is a Neovim plugin (Lua, Neovim 0.10+) that wraps `git log -L` to show the commit history of a selected line range in a floating viewer, with a diff preview and GitHub PR/commit links.
+
+## Commands
+
+- Format: `stylua lua/ plugin/` (config in `stylua.toml` — 2-space indent, 120-col, double quotes).
+- There is no test suite or build step. Manual testing is done by loading the plugin in Neovim and running `:Gloggles` on a visual range.
+
+## Architecture
+
+Entry points:
+- `plugin/gloggles.lua` — runs on plugin load: sets highlights, registers the `:Gloggles` user command (range-aware), and binds the default `<leader>gl` visual-mode keymap unless `vim.g.gloggles_no_default_keymap` is set.
+- `lua/gloggles/init.lua` — exposes `setup()` and lazily proxies other calls to `viewer`.
+
+Module responsibilities (all under `lua/gloggles/`):
+- `config.lua` — default options table and `setup()` merge.
+- `git.lua` — shells out to `git log -L` with a custom `COMMIT_SEP`/`Hash:`/`Date:`/`Author:`/`Subject:` format, parses the stream into commit records (subject → `pr_number` via `Merge pull request #N` or trailing `(#N)`), and builds GitHub URLs from the `origin` remote.
+- `viewer.lua` — builds the floating UI: a backdrop window, a commit-list buffer, and a lazily-created diff preview window. Owns state (current commit index, preview/help visibility), buffer-local keymaps (`j`/`k`/`p`/`h`/`<CR>`/`o`/`<Esc>`), and the `CursorMoved` autocmd that syncs the preview.
+- `preview.lua` — toggles the diff window and re-renders the diff buffer from the selected commit's `diff_lines`.
+- `help.lua` — floating key-reference overlay.
+- `highlights.lua` — `default = true` highlight links (`GlogglesDate`, `GlogglesAuthor`, `GlogglesSubject`, `GlogglesPR`, `GlogglesHelp`, `GlogglesHelpKey`).
+
+Key flow: visual selection → `viewer.open_for_visual_selection` → `git.repo_info` + `git.log_lines` → `create_viewer` renders the list, wires keymaps, and (optionally) opens the preview. The commit list is a `nofile` buffer; line-to-commit mapping is maintained in `line_to_commit` / `commit_first_line` tables so `j`/`k` and cursor moves stay in sync with the preview.
+
+## Docs
+
+User-facing docs live in `README.md` and `doc/gloggles.txt` (the `:help gloggles` page). Keep them aligned when changing keys, options, or highlight groups.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,4 +29,4 @@ Key flow: visual selection → `viewer.open_for_visual_selection` → `git.repo_
 
 ## Docs
 
-User-facing docs live in `README.md` and `doc/gloggles.txt` (the `:help gloggles` page). Keep them aligned when changing keys, options, or highlight groups.
+User-facing docs live in `README.md` and `doc/gloggles.txt` (the `:help gloggles` page). When you change anything user-visible — default keys, config options in `lua/gloggles/config.lua`, commands, or highlight groups — update all three in the same change: `README.md`, `doc/gloggles.txt`, and this `CLAUDE.md`. The help file and README should stay mirrored in content; `CLAUDE.md` only needs updating when the architecture notes above drift.

--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ With [lazy.nvim](https://github.com/folke/lazy.nvim):
 ```lua
 {
   "noizwaves/gloggles.nvim",
-  keys = {
-    { "<leader>gl", mode = "x", desc = "Gloggles: line history" },
-  },
   opts = {},
 }
 ```
@@ -41,9 +38,15 @@ Select lines in visual mode and press `<leader>gl`, or run `:Gloggles` with a ra
 | `h`     | Toggle the key reference overlay |
 | `<Esc>` | Close the viewer                 |
 
+## Help
+
+Run `:help gloggles` inside Neovim to open the bundled help page, which mirrors this README and is kept in `doc/gloggles.txt`.
+
+Inside the viewer, press `h` to toggle an overlay that lists the available keys without leaving the window.
+
 ## Configuration
 
-`setup` is optional — defaults are applied automatically. To override:
+`setup` is optional — defaults are applied automatically. See [`lua/gloggles/config.lua`](lua/gloggles/config.lua) for the full default table. To override:
 
 ```lua
 require("gloggles").setup({
@@ -53,7 +56,7 @@ require("gloggles").setup({
     list_width_ratio = 0.3,     -- commit list takes 30% of the viewer width
   },
   ui = {
-    title = " git log -L (line history) ",
+    title = "Gloggles (git line history)",
     backdrop_margin = 4,
   },
 })

--- a/doc/gloggles.txt
+++ b/doc/gloggles.txt
@@ -7,9 +7,10 @@ CONTENTS                                                   *gloggles-contents*
   2. Requirements .......................... |gloggles-requirements|
   3. Installation .......................... |gloggles-installation|
   4. Usage ................................. |gloggles-usage|
-  5. Configuration ......................... |gloggles-configuration|
-  6. Mappings .............................. |gloggles-mappings|
-  7. Highlights ............................ |gloggles-highlights|
+  5. Help .................................. |gloggles-help|
+  6. Configuration ......................... |gloggles-configuration|
+  7. Mappings .............................. |gloggles-mappings|
+  8. Highlights ............................ |gloggles-highlights|
 
 ==============================================================================
 1. INTRODUCTION                                       *gloggles-introduction*
@@ -33,9 +34,6 @@ the commit.
 With lazy.nvim: >lua
     {
       "noizwaves/gloggles.nvim",
-      keys = {
-        { "<leader>gl", mode = "x", desc = "Gloggles: line history" },
-      },
       opts = {},
     }
 <
@@ -53,7 +51,16 @@ run the command with a range:
     to the current line when no range is given.
 
 ==============================================================================
-5. CONFIGURATION                                     *gloggles-configuration*
+5. HELP                                                       *gloggles-help*
+
+Run `:help gloggles` to open this document. It mirrors the README and lives
+at `doc/gloggles.txt` in the repository.
+
+Inside the viewer, press `h` to toggle an overlay that lists the available
+keys without leaving the window.
+
+==============================================================================
+6. CONFIGURATION                                     *gloggles-configuration*
 
 Call `require("gloggles").setup({ ... })` or pass `opts` via lazy.nvim.
 
@@ -65,7 +72,7 @@ Defaults: >lua
         list_width_ratio = 0.3,
       },
       ui = {
-        title = " git log -L (line history) ",
+        title = "Gloggles (git line history)",
         backdrop_margin = 4,
       },
     }
@@ -74,7 +81,7 @@ To disable the default keymap before the plugin loads, set: >lua
     vim.g.gloggles_no_default_keymap = 1
 <
 ==============================================================================
-6. MAPPINGS                                               *gloggles-mappings*
+7. MAPPINGS                                               *gloggles-mappings*
 
 Inside the viewer:
 
@@ -86,7 +93,7 @@ Inside the viewer:
     <Esc>       Close the viewer
 
 ==============================================================================
-7. HIGHLIGHTS                                           *gloggles-highlights*
+8. HIGHLIGHTS                                           *gloggles-highlights*
 
 These groups are defined with `default = true` so your colorscheme wins:
 

--- a/lua/gloggles/config.lua
+++ b/lua/gloggles/config.lua
@@ -7,7 +7,7 @@ local defaults = {
     list_width_ratio = 0.3,
   },
   ui = {
-    title = " git log -L (line history) ",
+    title = "Gloggles (git line history)",
     backdrop_margin = 4,
   },
 }


### PR DESCRIPTION
## Context

Two docs-only commits that have been sitting on local `main` and need to go through a PR to reach `origin/main`.

## Problem

- No `CLAUDE.md`, so future Claude Code sessions have to re-derive the module layout and the git-log parsing contract each time.
- The viewer title and install/help docs were out of date after the rebrand.

## Solution

- Add a concise `CLAUDE.md` covering the one real command (stylua), the module responsibilities under `lua/gloggles/`, and the visual-selection → viewer flow. Deliberately short — no invented test commands, no file-by-file tour.
- Carry along the earlier rebrand commit that polishes the viewer title and the install/help docs.

## Testing

Docs-only; no behavior changes. Verified `stylua.toml` settings and module structure referenced in `CLAUDE.md` match the current tree.