### PR TITLE
Keyboard UX improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Entry points:
 Module responsibilities (all under `lua/gloggles/`):
 - `config.lua` — default options table and `setup()` merge.
 - `git.lua` — shells out to `git log -L` with a custom `COMMIT_SEP`/`Hash:`/`Date:`/`Author:`/`Subject:` format, parses the stream into commit records (subject → `pr_number` via `Merge pull request #N` or trailing `(#N)`), and builds GitHub URLs from the `origin` remote.
-- `viewer.lua` — builds the floating UI: a backdrop window, a commit-list buffer, and a lazily-created diff preview window. Owns state (current commit index, preview/help visibility), buffer-local keymaps (`j`/`k`/`p`/`h`/`<CR>`/`o`/`<Esc>`), and the `CursorMoved` autocmd that syncs the preview.
+- `viewer.lua` — builds the floating UI: a backdrop window, a commit-list buffer, and a lazily-created diff preview window. Owns state (current commit index, preview/help visibility), buffer-local keymaps (`j`/`k`/`p`/`h`/`c`/`<CR>`/`<Esc>`), and the `CursorMoved` autocmd that syncs the preview.
 - `preview.lua` — toggles the diff window and re-renders the diff buffer from the selected commit's `diff_lines`.
 - `help.lua` — floating key-reference overlay.
 - `highlights.lua` — `default = true` highlight links (`GlogglesDate`, `GlogglesAuthor`, `GlogglesSubject`, `GlogglesPR`, `GlogglesHelp`, `GlogglesHelpKey`).

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Select lines in visual mode and press `<leader>gl`, or run `:Gloggles` with a ra
 | ------- | -------------------------------- |
 | `j`/`k` | Next / previous commit           |
 | `p`     | Toggle the diff preview pane     |
-| `<CR>`  | Open the PR on GitHub            |
-| `o`     | Open the commit on GitHub        |
+| `<CR>`  | Open the PR on GitHub (falls back to the commit if there is no PR) |
+| `c`     | Copy the underlying `git log -L` command to the system clipboard |
 | `h`     | Toggle the key reference overlay |
 | `<Esc>` | Close the viewer                 |
 

--- a/doc/gloggles.txt
+++ b/doc/gloggles.txt
@@ -18,8 +18,8 @@ CONTENTS                                                   *gloggles-contents*
 gloggles is a viewer for `git log -L` (line history). Select a range of lines
 in a tracked file, invoke the viewer, and browse every commit that touched
 those lines with an inline diff preview. If the repository's origin points at
-GitHub, pressing <CR> opens the pull request in your browser and `o` opens
-the commit.
+GitHub, pressing <CR> opens the pull request in your browser (falling back to
+the commit page when the commit has no associated PR).
 
 ==============================================================================
 2. REQUIREMENTS                                       *gloggles-requirements*
@@ -87,8 +87,8 @@ Inside the viewer:
 
     j / k       Next / previous commit
     p           Toggle the diff preview pane
-    <CR>        Open the PR associated with the commit (GitHub origin)
-    o           Open the commit on GitHub
+    <CR>        Open the PR on GitHub, or the commit if there is no PR
+    c           Copy the underlying `git log -L` command to the clipboard
     h           Toggle the key reference overlay
     <Esc>       Close the viewer
 

--- a/lua/gloggles/git.lua
+++ b/lua/gloggles/git.lua
@@ -81,13 +81,17 @@ function M.parse_log_output(raw_lines)
   return commits
 end
 
-function M.log_lines(rel_path, start_line, end_line)
-  local cmd = string.format(
+function M.build_log_command(rel_path, start_line, end_line)
+  return string.format(
     'git --no-pager log --format="COMMIT_SEP%%nHash: %%H%%nDate: %%as%%nAuthor: %%an%%nSubject: %%s" --no-color -L %d,%d:%s',
     start_line,
     end_line,
     rel_path
   )
+end
+
+function M.log_lines(rel_path, start_line, end_line)
+  local cmd = M.build_log_command(rel_path, start_line, end_line)
   local raw = vim.fn.systemlist(cmd, nil)
   if vim.v.shell_error ~= 0 then
     return nil, table.concat(raw, "\n")

--- a/lua/gloggles/git.lua
+++ b/lua/gloggles/git.lua
@@ -81,17 +81,13 @@ function M.parse_log_output(raw_lines)
   return commits
 end
 
-function M.build_log_command(rel_path, start_line, end_line)
-  return string.format(
+function M.log_lines(rel_path, start_line, end_line)
+  local cmd = string.format(
     'git --no-pager log --format="COMMIT_SEP%%nHash: %%H%%nDate: %%as%%nAuthor: %%an%%nSubject: %%s" --no-color -L %d,%d:%s',
     start_line,
     end_line,
     rel_path
   )
-end
-
-function M.log_lines(rel_path, start_line, end_line)
-  local cmd = M.build_log_command(rel_path, start_line, end_line)
   local raw = vim.fn.systemlist(cmd, nil)
   if vim.v.shell_error ~= 0 then
     return nil, table.concat(raw, "\n")

--- a/lua/gloggles/help.lua
+++ b/lua/gloggles/help.lua
@@ -3,8 +3,8 @@ local M = {}
 local help_entries = {
   { "j/k", "navigate commits" },
   { "p", "toggle diff preview" },
-  { "Enter", "open PR in browser" },
-  { "o", "open commit in browser" },
+  { "Enter", "open PR / commit in browser" },
+  { "c", "copy git log command to clipboard" },
   { "h", "toggle this help" },
   { "Esc", "close" },
 }

--- a/lua/gloggles/viewer.lua
+++ b/lua/gloggles/viewer.lua
@@ -12,12 +12,12 @@ local function render_commit_list(buf, commits)
   local commit_first_line = {}
 
   for i, c in ipairs(commits) do
-    local line1 = c.date .. "  " .. c.author
+    local line1 = c.date .. " " .. c.author
     local base = #lines
 
     table.insert(lines, line1)
     table.insert(highlights, { base, 0, #c.date, "GlogglesDate" })
-    table.insert(highlights, { base, #c.date + 2, #line1, "GlogglesAuthor" })
+    table.insert(highlights, { base, #c.date + 1, #line1, "GlogglesAuthor" })
 
     table.insert(lines, c.subject)
     table.insert(highlights, { base + 1, 0, #c.subject, "GlogglesSubject" })

--- a/lua/gloggles/viewer.lua
+++ b/lua/gloggles/viewer.lua
@@ -202,7 +202,7 @@ local function create_viewer(commits, git_root, rel_path, start_line, end_line)
   end, kopts)
 
   vim.keymap.set("n", "c", function()
-    local cmd = git.build_log_command(rel_path, start_line, end_line)
+    local cmd = string.format("git log -L %d,%d:%s", start_line, end_line, rel_path)
     vim.fn.setreg("+", cmd)
     vim.fn.setreg("*", cmd)
     vim.notify("Copied git log command to clipboard", vim.log.levels.INFO)

--- a/lua/gloggles/viewer.lua
+++ b/lua/gloggles/viewer.lua
@@ -186,20 +186,11 @@ local function create_viewer(commits, git_root, rel_path, start_line, end_line)
 
   vim.keymap.set("n", "<CR>", function()
     local c = commits[state.current_commit_idx]
-    if not c or not c.pr_number then
-      vim.notify("No PR link for this commit", vim.log.levels.INFO)
-      return
-    end
-    if not pr_base_url then
-      vim.notify("No remote URL configured", vim.log.levels.WARN)
-      return
-    end
-    vim.ui.open(pr_base_url .. c.pr_number)
-  end, kopts)
-
-  vim.keymap.set("n", "o", function()
-    local c = commits[state.current_commit_idx]
     if not c then
+      return
+    end
+    if c.pr_number and pr_base_url then
+      vim.ui.open(pr_base_url .. c.pr_number)
       return
     end
     local url = git.get_commit_url(git_root, c.hash)
@@ -208,6 +199,13 @@ local function create_viewer(commits, git_root, rel_path, start_line, end_line)
     else
       vim.notify("No remote URL configured", vim.log.levels.WARN)
     end
+  end, kopts)
+
+  vim.keymap.set("n", "c", function()
+    local cmd = git.build_log_command(rel_path, start_line, end_line)
+    vim.fn.setreg("+", cmd)
+    vim.fn.setreg("*", cmd)
+    vim.notify("Copied git log command to clipboard", vim.log.levels.INFO)
   end, kopts)
 
   vim.api.nvim_create_autocmd("WinEnter", {


### PR DESCRIPTION
## Context

Two separate keys in the viewer (`<CR>` for the PR, `o` for the commit) made you remember which key applies to each commit — PRs are only set on some commits, so `<CR>` often just notified "No PR link for this commit" and you'd switch to `o`. Separately, I wanted a way to grab the underlying `git log -L` invocation so I could re-run it or share it outside of Neovim.

## Problem

- Picking between `<CR>` and `o` is noise; the user almost always wants "open whatever exists on GitHub for this commit".
- No way to extract the `git log -L N,M:path` command from the viewer without reconstructing it by hand.

## Solution

- `<CR>` now opens the PR when the commit has one and the repo has a GitHub origin, otherwise falls back to the commit page. `o` is removed.
- New `c` keymap copies the user-friendly `git log -L N,M:path` form (not the internal `--format=…` plumbing) to the system clipboard. Over SSH this lands on the local machine's clipboard via Neovim's OSC 52 support.
- Minor: tightened the date/author spacing in the commit list from two spaces to one.
- README, `doc/gloggles.txt`, the in-viewer help overlay, and `CLAUDE.md` updated to match.

## Testing

Manually exercised `:Gloggles` on visual ranges in this repo:

- `<CR>` on a commit with a PR trailer opens the PR; on a commit without one it opens the commit page.
- `c` copies `git log -L 1,13:README.md` (or similar) to the clipboard; pasted into a terminal it runs standalone and prints the same commits shown in the viewer.
- `h` overlay reflects the new bindings.

No automated tests exist in this repo.