### PR TITLE
Fix GitHub URLs for repos containing period characters

### DIFF
--- a/lua/gloggles/git.lua
+++ b/lua/gloggles/git.lua
@@ -14,10 +14,11 @@ local function parse_remote(git_root)
   if not remote or remote == "" then
     return nil
   end
-  local owner, repo = remote:match("github%.com[:/]([^/]+)/([^/%.]+)")
+  local owner, repo = remote:match("github%.com[:/]([^/]+)/(.+)")
   if not owner then
     return nil
   end
+  repo = repo:gsub("%.git$", ""):gsub("/$", "")
   return owner, repo
 end
 


### PR DESCRIPTION
## Problem

Opening a PR link from the commit viewer in a repo whose name contains a dot (e.g. `telescope.nvim`) navigated to the wrong URL — the host segment was truncated at the first dot, so `nvim-telescope/telescope.nvim` became `nvim-telescope/telescope`, yielding a 404-style redirect to an unrelated repo.

## Solution

`parse_remote` in `lua/gloggles/git.lua` used `([^/%.]+)` to capture the repo name, which stopped at any dot. Replaced with a greedy capture followed by an explicit strip of a trailing `.git` suffix (and any trailing slash). This preserves dots inside the repo name while still handling both SSH (`git@github.com:owner/repo.git`) and HTTPS (`https://github.com/owner/repo.git`) remotes.

## Testing

Manually verified by opening `:Gloggles` on a file in a `*.nvim` repo and confirming the PR/commit URLs now resolve correctly. No automated test suite exists in this project.