### PR TITLE
Add preview GIF to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A viewer for `git log -L` (line history) in Neovim. Select lines, press a key, and browse every commit that touched them — with an inline diff preview and one-keystroke jumps to the pull request or commit on GitHub.
 
+![Preview](https://i.imgur.com/YwLtZvT.gif)
+
 ## Requirements
 
 - Neovim 0.10+


### PR DESCRIPTION
## Context

New users landing on the repo have no immediate sense of what the plugin looks like in action — they have to read through the description and mentally model the UI.

## Problem

The README had no visual preview, making it harder to quickly evaluate whether the plugin fits a user's workflow.

## Solution

Added a preview GIF near the top of the README, immediately after the description, so visitors can see the plugin in action before reading further.

## Testing

Verified the image renders correctly by previewing the Markdown locally.