### PR TITLE
Add nvim-dev Claude skill and dev tooling setup

### DIFF
--- a/.claude/skills/nvim-dev/SKILL.md
+++ b/.claude/skills/nvim-dev/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: nvim-dev
 description: Use when developing or debugging gloggles.nvim to launch a minimal Neovim instance that loads the plugin and verify changes via remote RPC
+allowed-tools: Bash(.claude/skills/nvim-dev/bin/nvim-start:*), Bash(.claude/skills/nvim-dev/bin/nvim-verify:*), Bash(.claude/skills/nvim-dev/bin/nvim-stop:*), Bash(nvim --server *)
 ---
 
 # Develop gloggles.nvim

--- a/.claude/skills/nvim-dev/SKILL.md
+++ b/.claude/skills/nvim-dev/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: nvim-dev
+description: Use when developing or debugging gloggles.nvim to launch a minimal Neovim instance that loads the plugin and verify changes via remote RPC
+---
+
+# Develop gloggles.nvim
+
+Spawn a Neovim instance with a minimal config that loads only `gloggles.nvim` from this repo, then drive it over its `--listen` socket to verify behavior after edits.
+
+## Workflow
+
+```
+nvim-start → dynamic checks → nvim-verify → nvim-stop
+```
+
+1. Start the server: `.claude/skills/nvim-dev/bin/nvim-start` (prints the socket path).
+2. Run change-specific checks using `nvim --server <sock> --remote-expr 'luaeval("...")'`.
+3. Run baseline health check: `.claude/skills/nvim-dev/bin/nvim-verify`.
+4. **Always** stop the server: `.claude/skills/nvim-dev/bin/nvim-stop` (even if checks fail).
+
+The socket path is stored in `/tmp/gloggles-nvim-dev.state`. The minimal init at `.claude/skills/nvim-dev/minimal_init.lua` prepends the repo to `runtimepath` and calls `require("gloggles").setup({})` — no user config, no other plugins.
+
+**Important:** The spawned Neovim loads Lua files at startup. If you edit a file and need to verify the new version, stop and restart the server (`nvim-stop` then `nvim-start`) so the updated code is loaded. A partial `package.loaded[...] = nil` reload works for some modules but is not reliable for `plugin/gloggles.lua`.
+
+## Dynamic Verification Patterns
+
+Construct `luaeval` queries based on what you changed. Read the socket path from the `nvim-start` output.
+
+**Important:** Always use the literal absolute socket path (e.g., `/tmp/gloggles-nvim-dev-12345.sock`) directly in `nvim --server` commands. Do NOT store it in a shell variable like `$SOCK` — variable expansion triggers `simple_expansion` permission warnings.
+
+### Config changed (`lua/gloggles/config.lua`)
+
+```bash
+# Inspect the merged options table
+nvim --server /tmp/gloggles-nvim-dev-XXXXX.sock --remote-expr 'luaeval("vim.inspect(require(\"gloggles.config\").options)")'
+```
+
+### Command or keymap changed (`plugin/gloggles.lua`)
+
+```bash
+# :Gloggles command is registered and range-aware
+nvim --server /tmp/gloggles-nvim-dev-XXXXX.sock --remote-expr 'luaeval("vim.api.nvim_get_commands({})[\"Gloggles\"].range")'
+
+# Default <leader>gl visual-mode keymap exists
+nvim --server /tmp/gloggles-nvim-dev-XXXXX.sock --remote-expr 'luaeval("vim.fn.maparg(\"<leader>gl\", \"x\") ~= \"\"")'
+```
+
+### Highlights changed (`lua/gloggles/highlights.lua`)
+
+```bash
+nvim --server /tmp/gloggles-nvim-dev-XXXXX.sock --remote-expr 'luaeval("vim.fn.hlexists(\"GlogglesSubject\")")'
+```
+
+### Git parsing changed (`lua/gloggles/git.lua`)
+
+Because the spawned nvim inherits its `cwd` from where `nvim-start` was invoked, run the starter from inside a git repo to exercise `repo_info` / `log_lines`:
+
+```bash
+nvim --server /tmp/gloggles-nvim-dev-XXXXX.sock --remote-expr 'luaeval("vim.inspect(require(\"gloggles.git\").repo_info())")'
+```
+
+### Viewer logic changed (`lua/gloggles/viewer.lua`)
+
+Open a file and trigger the viewer end-to-end:
+
+```bash
+# Open a tracked file (in the cwd the server started from)
+nvim --server /tmp/gloggles-nvim-dev-XXXXX.sock --remote-send ':edit README.md<CR>'
+
+# Invoke :Gloggles over an explicit range
+nvim --server /tmp/gloggles-nvim-dev-XXXXX.sock --remote-send ':1,10Gloggles<CR>'
+
+# Inspect floating windows that appeared
+nvim --server /tmp/gloggles-nvim-dev-XXXXX.sock --remote-expr 'luaeval("#vim.api.nvim_list_wins()")'
+```
+
+## When Multiple Files Changed
+
+Verify each changed area, then run `nvim-verify` for the baseline check. Don't skip dynamic checks just because you'll run the baseline — the baseline only covers load-time health.
+
+## Error Handling
+
+- If `nvim-start` fails (exit 2): plugin has a fatal load error. Check the error output, fix, and retry.
+- If a `luaeval` query fails: the feature you changed may have a runtime error. The error message from nvim will indicate the problem.
+- **Always run `nvim-stop`** at the end, even after failures.

--- a/.claude/skills/nvim-dev/bin/nvim-start
+++ b/.claude/skills/nvim-dev/bin/nvim-start
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STATE_FILE="/tmp/gloggles-nvim-dev.state"
+SOCK="/tmp/gloggles-nvim-dev-$$.sock"
+TIMEOUT="${1:-15}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_FILE="$SCRIPT_DIR/../minimal_init.lua"
+
+rm -f "$SOCK"
+
+if [ -f "$STATE_FILE" ]; then
+  echo "Warning: stale state file found, cleaning up previous session"
+  "$SCRIPT_DIR/nvim-stop" 2>/dev/null || true
+fi
+
+if [ -n "${TMUX:-}" ]; then
+  WINDOW_ID=$(tmux new-window -d -P -F '#{window_id}' "nvim -u $INIT_FILE --listen $SOCK")
+  echo "SOCK=$SOCK" > "$STATE_FILE"
+  echo "WINDOW_ID=$WINDOW_ID" >> "$STATE_FILE"
+  echo "MODE=tmux" >> "$STATE_FILE"
+else
+  nvim --headless -u "$INIT_FILE" --listen "$SOCK" &
+  NVIM_PID=$!
+  echo "SOCK=$SOCK" > "$STATE_FILE"
+  echo "NVIM_PID=$NVIM_PID" >> "$STATE_FILE"
+  echo "MODE=headless" >> "$STATE_FILE"
+fi
+
+elapsed=0
+while ! nvim --server "$SOCK" --remote-expr '1' &>/dev/null; do
+  sleep 0.2
+  elapsed=$((elapsed + 1))
+  if [ "$elapsed" -ge $((TIMEOUT * 5)) ]; then
+    echo "ERROR: nvim server failed to start within ${TIMEOUT}s" >&2
+    "$SCRIPT_DIR/nvim-stop" 2>/dev/null || true
+    exit 2
+  fi
+done
+
+echo "$SOCK"

--- a/.claude/skills/nvim-dev/bin/nvim-stop
+++ b/.claude/skills/nvim-dev/bin/nvim-stop
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+STATE_FILE="/tmp/gloggles-nvim-dev.state"
+
+if [ ! -f "$STATE_FILE" ]; then
+  exit 0
+fi
+
+# shellcheck source=/dev/null
+source "$STATE_FILE"
+
+if [ -S "${SOCK:-}" ]; then
+  nvim --server "$SOCK" --remote-send ':qall!<CR>' 2>/dev/null || true
+  sleep 0.3
+fi
+
+case "${MODE:-}" in
+  tmux)
+    if [ -n "${WINDOW_ID:-}" ]; then
+      tmux kill-window -t "$WINDOW_ID" 2>/dev/null || true
+    fi
+    ;;
+  headless)
+    if [ -n "${NVIM_PID:-}" ]; then
+      kill "$NVIM_PID" 2>/dev/null || true
+    fi
+    ;;
+esac
+
+rm -f "${SOCK:-}" "$STATE_FILE"

--- a/.claude/skills/nvim-dev/bin/nvim-verify
+++ b/.claude/skills/nvim-dev/bin/nvim-verify
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+STATE_FILE="/tmp/gloggles-nvim-dev.state"
+
+if [ ! -f "$STATE_FILE" ]; then
+  echo "ERROR: no nvim server running (state file not found)" >&2
+  exit 2
+fi
+
+# shellcheck source=/dev/null
+source "$STATE_FILE"
+
+if [ -z "${SOCK:-}" ] || [ ! -S "$SOCK" ]; then
+  echo "ERROR: nvim socket not found at ${SOCK:-<unset>}" >&2
+  exit 2
+fi
+
+exit_code=0
+
+echo "=== Startup Errors ==="
+errmsg=$(nvim --server "$SOCK" --remote-expr 'luaeval("vim.v.errmsg")' 2>&1)
+if [ -z "$errmsg" ]; then
+  echo "PASS: no startup errors"
+else
+  echo "FAIL: startup error detected"
+  echo "  $errmsg"
+  exit_code=1
+fi
+
+echo ""
+echo "=== :Gloggles Command ==="
+cmd_exists=$(nvim --server "$SOCK" --remote-expr 'luaeval("vim.fn.exists(\":Gloggles\") == 2")' 2>&1)
+if [ "$cmd_exists" = "true" ]; then
+  echo "PASS: :Gloggles command registered"
+else
+  echo "FAIL: :Gloggles command not found"
+  echo "  $cmd_exists"
+  exit_code=1
+fi
+
+echo ""
+echo "=== Module Requires ==="
+requires_ok=$(nvim --server "$SOCK" --remote-expr 'luaeval("(pcall(require, \"gloggles\")) and (pcall(require, \"gloggles.viewer\")) and (pcall(require, \"gloggles.git\")) and (pcall(require, \"gloggles.config\")) and (pcall(require, \"gloggles.highlights\"))")' 2>&1)
+if [ "$requires_ok" = "true" ]; then
+  echo "PASS: all gloggles modules require cleanly"
+else
+  echo "FAIL: one or more gloggles modules failed to require"
+  echo "  $requires_ok"
+  exit_code=1
+fi
+
+echo ""
+echo "=== Default Highlights ==="
+hl_ok=$(nvim --server "$SOCK" --remote-expr 'luaeval("vim.fn.hlexists(\"GlogglesSubject\") == 1 and vim.fn.hlexists(\"GlogglesPR\") == 1 and vim.fn.hlexists(\"GlogglesDate\") == 1")' 2>&1)
+if [ "$hl_ok" = "true" ]; then
+  echo "PASS: default highlight groups defined"
+else
+  echo "FAIL: expected highlight groups missing"
+  echo "  $hl_ok"
+  exit_code=1
+fi
+
+exit $exit_code

--- a/.claude/skills/nvim-dev/minimal_init.lua
+++ b/.claude/skills/nvim-dev/minimal_init.lua
@@ -1,0 +1,9 @@
+local this = debug.getinfo(1, "S").source:sub(2)
+local repo_root = vim.fn.fnamemodify(this, ":p:h:h:h:h")
+
+vim.opt.runtimepath:prepend(repo_root)
+vim.opt.packpath = vim.o.runtimepath
+
+vim.cmd("runtime! plugin/gloggles.lua")
+
+require("gloggles").setup({})

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -1,0 +1,6 @@
+pre-commit:
+  commands:
+    stylua:
+      glob: "*.lua"
+      run: stylua {staged_files}
+      stage_fixed: true

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[tools]
+stylua = "latest"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,2 +1,3 @@
 [tools]
 stylua = "latest"
+lefthook = "latest"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - Format: `stylua lua/ plugin/` (config in `stylua.toml` — 2-space indent, 120-col, double quotes).
 - There is no test suite or build step. Manual testing is done by loading the plugin in Neovim and running `:Gloggles` on a visual range.
+- Dev tooling (`stylua`, `lefthook`) is pinned in `.mise.toml`; run `mise install` after cloning. Then `lefthook install` wires up `.lefthook.yml`, which auto-formats staged Lua files on commit via `stylua`.
+- There is an `nvim-dev` Claude skill at `.claude/skills/nvim-dev/` that spawns a minimal nvim loading just this plugin for RPC-driven verification. See that skill's `SKILL.md` for the start/verify/stop workflow.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ All highlight groups are defined with `default = true` so your colorscheme takes
 - `GlogglesHelp` — help overlay text (links to `Comment`)
 - `GlogglesHelpKey` — help overlay keys (links to `Special`)
 
+## Development
+
+Dev tooling (`stylua`, `lefthook`) is pinned in `.mise.toml`. With [mise](https://mise.jdx.dev/) installed, run `mise install` to get both.
+
+After cloning, wire up the pre-commit hook so Lua changes are formatted automatically:
+
+```
+lefthook install
+```
+
+The hook is configured in `.lefthook.yml` and runs `stylua` on staged `*.lua` files, re-staging the formatted output.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Context

Developing and debugging this plugin today means manually running `nvim -u some_init.lua` and eyeballing results. My dotfiles repo already has a `verify-nvim-config` skill that solves the analogous problem for personal Neovim config in general by spawning a background nvim on a known socket and driving it over RPC — this PR ports that pattern into the repo, scoped to gloggles.

## Problem

- No repeatable way for a contributor (human or agent) to spin up a minimal nvim that loads only this plugin and verify changes programmatically.
- Formatting drift is easy because `stylua` isn't wired into any hook.
- Tool versions aren't pinned, so contributors have to figure out the right toolchain themselves.

## Solution

**`nvim-dev` Claude skill** (`.claude/skills/nvim-dev/`):
- `minimal_init.lua` (committed) resolves the repo root from its own file path, prepends it to `runtimepath`, and runs `require("gloggles").setup({})` — no user config, no lazy, no unrelated plugins.
- `bin/nvim-start|nvim-verify|nvim-stop` mirror the reference skill's start/verify/stop flow with namespaced state (`/tmp/gloggles-nvim-dev.state`) so it doesn't collide with `verify-nvim-config`.
- `nvim-verify` drops the lazy.nvim baseline (not present here) and instead checks: no startup errors, `:Gloggles` command registered, all gloggles modules `require()` cleanly, and default highlight groups defined.
- `SKILL.md` declares `allowed-tools` for the three scripts plus `nvim --server *`, and documents gloggles-specific dynamic verification patterns.

**Dev tooling:**
- `.mise.toml` pins `stylua` and `lefthook` to latest.
- `.lefthook.yml` defines a `pre-commit` hook that runs `stylua` on staged `*.lua` files with `stage_fixed: true` to re-stage the formatted output.
- `README.md` gains a `## Development` section explaining `mise install` + `lefthook install`. `CLAUDE.md` gets a matching note plus a pointer to the skill.

## Testing

The skill was run and used to look for bugs in the UI. It was able to find a couple.