### PR TITLE
Fix various visual bugs

### DIFF
--- a/lua/gloggles/viewer.lua
+++ b/lua/gloggles/viewer.lua
@@ -53,8 +53,8 @@ end
 function M.compute_layout(preview_visible)
   local opts = config.get()
   local editor_w = vim.o.columns
-  -- reserve space for cmdline + statusline so edge-to-edge (ratio=1.0) fits
-  local editor_h = vim.o.lines - vim.o.cmdheight - 1
+  -- reserve only the cmdline; the float overlays the statusline area
+  local editor_h = vim.o.lines - vim.o.cmdheight
 
   local total_w = math.floor(editor_w * opts.ui.width_ratio)
   local total_h = math.floor(editor_h * opts.ui.height_ratio)

--- a/lua/gloggles/viewer.lua
+++ b/lua/gloggles/viewer.lua
@@ -96,9 +96,30 @@ local function create_viewer(commits, git_root, rel_path, start_line, end_line)
   local opts = config.get()
   local layout = M.compute_layout(opts.preview.enabled_by_default)
 
+  local bg_win = vim.api.nvim_get_current_win()
+  local saved_bg_winhl = vim.wo[bg_win].winhighlight
+  vim.wo[bg_win].winhighlight = (saved_bg_winhl ~= "" and saved_bg_winhl .. "," or "")
+    .. "CursorNC:GlogglesHiddenCursor"
+
+  local backdrop_buf = vim.api.nvim_create_buf(false, true)
+  vim.bo[backdrop_buf].buftype = "nofile"
+  vim.bo[backdrop_buf].swapfile = false
+  local backdrop_win = vim.api.nvim_open_win(backdrop_buf, false, {
+    relative = "editor",
+    width = vim.o.columns,
+    height = math.max(1, vim.o.lines - vim.o.cmdheight),
+    row = 0,
+    col = 0,
+    style = "minimal",
+    focusable = false,
+    zindex = 49,
+  })
+  vim.wo[backdrop_win].winhighlight = "Normal:GlogglesNormal"
+
   local list_buf = vim.api.nvim_create_buf(false, true)
   vim.bo[list_buf].buftype = "nofile"
   vim.bo[list_buf].swapfile = false
+  vim.bo[list_buf].bufhidden = "wipe"
 
   local list_win = vim.api.nvim_open_win(list_buf, true, {
     relative = "editor",
@@ -126,6 +147,8 @@ local function create_viewer(commits, git_root, rel_path, start_line, end_line)
     list_win = list_win,
     diff_buf = diff_buf,
     diff_win = nil,
+    backdrop_win = backdrop_win,
+    backdrop_buf = backdrop_buf,
     commits = commits,
     git_root = git_root,
     rel_path = rel_path,
@@ -183,6 +206,10 @@ local function create_viewer(commits, git_root, rel_path, start_line, end_line)
     once = true,
     callback = function()
       vim.o.guicursor = saved_guicursor
+      if pcall(vim.api.nvim_win_is_valid, bg_win) and vim.api.nvim_win_is_valid(bg_win) then
+        vim.wo[bg_win].winhighlight = saved_bg_winhl
+      end
+      pcall(vim.api.nvim_win_close, backdrop_win, true)
     end,
   })
 
@@ -258,9 +285,11 @@ local function create_viewer(commits, git_root, rel_path, start_line, end_line)
   local kopts = { buffer = list_buf, nowait = true }
   vim.keymap.set("n", "<Esc>", function()
     for _, win in ipairs(vim.api.nvim_list_wins()) do
-      local cfg = vim.api.nvim_win_get_config(win)
-      if cfg.relative ~= "" then
-        pcall(vim.api.nvim_win_close, win, true)
+      if vim.api.nvim_win_is_valid(win) then
+        local ok, cfg = pcall(vim.api.nvim_win_get_config, win)
+        if ok and cfg.relative ~= "" then
+          pcall(vim.api.nvim_win_close, win, true)
+        end
       end
     end
   end, kopts)

--- a/lua/gloggles/viewer.lua
+++ b/lua/gloggles/viewer.lua
@@ -47,8 +47,9 @@ local function render_commit_list(buf, commits)
   return line_to_commit, commit_first_line
 end
 
--- Layout is computed in terms of inner content sizes; each pane has a
--- rounded border rendered 1 cell outside its content rectangle.
+-- Layout is computed in terms of outer (border-inclusive) rectangles — the
+-- `row`/`col` passed to nvim_open_win position the top-left of the bordered
+-- window, so the content sits 1 cell inset from the outer rectangle.
 function M.compute_layout(preview_visible)
   local opts = config.get()
   local editor_w = vim.o.columns
@@ -62,8 +63,8 @@ function M.compute_layout(preview_visible)
   local base_row = math.floor((editor_h - total_h) / 2)
 
   local inner_h = total_h - 2
-  local list_row = base_row + 1
-  local list_col = base_col + 1
+  local list_row = base_row
+  local list_col = base_col
 
   local layout = {
     base_col = base_col,


### PR DESCRIPTION
## Context

While exercising the plugin through the `nvim-dev` skill, two visual defects stood out whenever the floating viewer opened over a real buffer:

1. `CursorNC` rendered on the underlying window, leaving a stray highlighted cell on the source buffer's cursor line.
2. The source buffer's text bled through around and between the floats — even though `CLAUDE.md` claimed a "backdrop window" existed, no such window was actually created.

## Problem

Expected: the viewer should present as a self-contained overlay — nothing from the underlying buffer visible behind it, and no cursor artifact on the dimmed window.

Actual: the source buffer's first line, inter-pane gap, and any area around the rounded borders remained visible, and the inactive cursor sat on top of it all.

## Solution

- Override `CursorNC` on the captured background window via `winhighlight` (appended to any prior value so restoration is exact), undone in the existing `BufWipeout` cleanup.
- Add a real backdrop float — full-editor size, `zindex = 49` so the list (50) and diff (50) sit on top, non-focusable, empty scratch buffer with `Normal:GlogglesNormal`.
- Set `bufhidden = wipe` on the list buffer so `<Esc>` closing the window actually triggers the `BufWipeout` autocmd that restores `guicursor` / `winhighlight` and closes the backdrop — previously that cleanup path never ran.
- Guard the `<Esc>` window-close loop with `nvim_win_is_valid` + `pcall` around `nvim_win_get_config`, because closing the list window now cascades into closing the backdrop (via `BufWipeout`) and invalidates window ids mid-iteration.

Two pre-existing layout bugs surfaced once the backdrop exposed them:

- `compute_layout` treated `nvim_open_win`'s `row`/`col` as content position, but the API uses border-inclusive top-left. Floats were always offset 1 row down and 1 col right — invisible when the buffer text filled the strip, obvious as blank once the backdrop covered it. Removed the `+ 1` on both axes.
- `editor_h` reserved space for both the cmdline and a statusline row, leaving the last row above the cmdline uncovered at `ratio = 1.0`. The backdrop already extends over the statusline area, so the floats can too; dropped the extra `-1`.

## Testing

Drove the running plugin over RPC via the `nvim-dev` skill:

- Confirmed both bugs reproduced pre-fix by inspecting `nvim_win_get_config` and `winhighlight` on the background window.
- Post-fix, verified four windows (background + backdrop at zindex 49 + list/diff at 50), correct `winhighlight` on each, and that `screenchar` reads solid borders from the very first to the last row/column when `ratio = 1.0`, both with and without the preview pane.
- Sent `<Esc>` and confirmed teardown: list/diff/backdrop closed, `guicursor` restored, background `winhighlight` reverted to its captured value, and re-invoking `:Gloggles` works cleanly.
- Ran the skill's baseline `nvim-verify` (startup, command registration, module loads, highlights) — all pass. `stylua lua/ plugin/` run.